### PR TITLE
ch4/netmod: Unwind comm non-inline impl migration

### DIFF
--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -234,6 +234,32 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_create_intercomm_from_lpids(MPIR_Comm * ne
     return ret;
 }
 
+int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_COMM_CREATE_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_COMM_CREATE_HOOK);
+
+    ret = MPIDI_NM_func->mpi_comm_create_hook(comm);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMM_CREATE_HOOK);
+    return ret;
+}
+
+int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);
+
+    ret = MPIDI_NM_func->mpi_comm_free_hook(comm);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
 {
     int ret;

--- a/src/mpid/ch4/netmod/src/netmod_impl.c
+++ b/src/mpid/ch4/netmod/src/netmod_impl.c
@@ -13,32 +13,6 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
 #include "mpidimpl.h"
 
-int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_COMM_CREATE_HOOK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_COMM_CREATE_HOOK);
-
-    ret = MPIDI_NM_func->mpi_comm_create_hook(comm);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMM_CREATE_HOOK);
-    return ret;
-}
-
-int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
-{
-    int ret;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);
-
-    ret = MPIDI_NM_func->mpi_comm_free_hook(comm);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);
-    return ret;
-}
-
 int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr)
 {
     int ret;


### PR DESCRIPTION
This patch reverts the migration of comm non-inline functions
to netmod_impl.c, to demonstrate that now we can build netmods in
both inline/noinline modes without introducing netmod_impl.c.