### PR TITLE
Update Etags wiki to reference current directories

### DIFF
--- a/doc/wiki/source_code/Etags.md
+++ b/doc/wiki/source_code/Etags.md
@@ -56,7 +56,7 @@ if [ "$CHANNEL" = "all" ] ; then
 else
     find src \(                 \
              \( -path src/mpid -o       \
-                    -path src/pm/smpd -o    \
+                    -path src/pm/hydra -o    \
                     -path src/pmi -o        \
                     -path src/mpi/romio -o  \
                 -path src/binding -o        \
@@ -77,8 +77,8 @@ else
              -print
 
     if [ "$CHANNEL" != "dcmf" ] ; then
-        find src/pmi/pmi2                         \
-             src/pmi/simple                       \
+        find src/pmi/include                      \
+             src/pmi/src                          \
          src/mpid/ch3/channels/${CHANNEL}                 \
          src/mpid/common                          \
          src/mpid/ch3                         \


### PR DESCRIPTION
## Summary
- update the Etags documentation to prune the current Hydra process manager directory
- point the PMI find command to the existing include and src directories

## Testing
- find src \( \( -path src/mpid -o -path src/pm/hydra -o -path src/pmi -o -path src/mpi/romio -o -path src/binding -o -path src/mpe2 -o -path src/util/multichannel \) -prune -o -name '*.[chi]' -o -name '*.h.in' \) -a ! -name state_names.h -a ! -name mpiallstates.h -a ! -name defmsg.h -a ! -name windefmsg.h -a ! -name 'tokens.[ch]' -a ! -name 'parser.[ch]' -a ! -name '*.#*' -type f -print | wc -l
- find src/pmi/include src/pmi/src src/mpid/ch3/channels/nemesis src/mpid/common src/mpid/ch3 \( -path src/mpid/common/sock/iocp -o -path src/mpid/ch3/channels -o -path src/mpid/ch3/channels/nemesis/nemesis/netmod/wintcp \) -prune -o \( -name '*.[chi]' -o -name '*.h.in' \) -a ! -name '*.#*' -a ! -name 'tokens.[ch]' -a ! -name 'parser.[ch]' -print | wc -l

------
https://chatgpt.com/codex/tasks/task_e_68d7518de0988325aff1f90ca273f85e